### PR TITLE
Removing trailing slash from the get request

### DIFF
--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,3 @@
+from dotenv import load_dotenv
+
+load_dotenv()

--- a/frontend/src/components/Activities.jsx
+++ b/frontend/src/components/Activities.jsx
@@ -13,7 +13,7 @@ function Activities() {
   
   const loadActivities = (token) => {
     setIsLoading(true);
-    const url = `${import.meta.env.VITE_BACKEND_URL}/activities/`;
+    const url = `${import.meta.env.VITE_BACKEND_URL}/activities`;
     fetch(url, {
       method: 'GET',
       headers: {


### PR DESCRIPTION
This was causing a 307 redirect error in the backend. Also, we need to load the dotenv file for the tests to run.